### PR TITLE
Invoke builds with PROFILE="-Werror"

### DIFF
--- a/bin/pg-build-test
+++ b/bin/pg-build-test
@@ -4,7 +4,7 @@
 
 set -eux
 
-make all
+make all PROFILE="-Werror"
 make install
 status=0
 make installcheck PGUSER=postgres || status=$?


### PR DESCRIPTION
Changes between PostgreSQL major versions are often type changes in
function arguments, which gcc only raises warnings about. Invoke all
builds with -Werror to make sure everything is caught.

PROFILE is the recommended way to inject extra flags into the PGXS build
process.