### PR TITLE
[pg-build-test] Allow setting PROFILE from ENV

### DIFF
--- a/bin/pg-build-test
+++ b/bin/pg-build-test
@@ -4,7 +4,11 @@
 
 set -eux
 
-make all PROFILE="-Werror"
+# set PROFILE to a default of -Werror, otherwise use the passed in value. Note
+# the double dash is intentional.
+export PROFILE="${PROFILE:--Werror}"
+
+make all
 sudo make install
 status=0
 make installcheck PGUSER=postgres || status=$?


### PR DESCRIPTION
Keeps current default. 

See discussion in https://github.com/pgxn/docker-pgxn-tools/pull/1. This allows setting `PROFILE` from github action files, e.g.:
```
jobs:
  test:
    name: Test
    env:
      PROFILE: "-std=c90"
```