### PR TITLE
Fix Git archiving and improve docs

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -12,13 +12,18 @@ jobs:
       matrix:
         pg: [16, 15, 14, 13, 12, 11, 10, 9.6, 9.5, 9.4, 9.3, 9.2, 9.1, '9.0', 8.4, 8.3, 8.2]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build Image
         run: docker build -t pgxn-tools-test .
       - name: Test as root
-        run: "docker run --rm --mount \"type=bind,src=$(pwd)/test,dst=/repo\" pgxn-tools-test /repo/runtest.sh ${{ matrix.pg }}"
+        run: "docker run -w /repo --rm --volume \"$(pwd):/repo\" pgxn-tools-test ./test/runtest.sh ${{ matrix.pg }}"
       - name: Test as non-root
-        run: "docker run --rm --mount \"type=bind,src=$(pwd)/test,dst=/repo\" -e AS_USER=worker pgxn-tools-test /repo/runtest.sh ${{ matrix.pg }}"
+        run: "docker run -w /repo --rm --volume \"$(pwd):/repo\" -e AS_USER=worker pgxn-tools-test ./test/runtest.sh ${{ matrix.pg }}"
+      - name: Test as root without Repo
+        run: "docker run -w /repo --rm --volume \"$(pwd)/test:/repo\" pgxn-tools-test ./runtest.sh ${{ matrix.pg }} nogit"
+      - name: Test as non-root without Repo
+        run: "docker run -w /repo --rm --volume \"$(pwd)/test:/repo\" -e AS_USER=worker pgxn-tools-test ./runtest.sh ${{ matrix.pg }} nogit"
+
   publish:
     # Publish for a tag starting with v.
     name: Push to Docker Hub
@@ -27,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: pgxn/pgxn-tools
           tags: |
@@ -42,13 +47,13 @@ jobs:
             org.opencontainers.image.title=PGXN Tools
             org.opencontainers.image.licenses=PostgreSQL
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and Push
         # https://github.com/marketplace/actions/build-and-push-docker-images
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN chmod +x /usr/local/bin/apt.postgresql.org.sh \
     && apt-get install -y --no-install-recommends \
         build-essential clang llvm llvm-dev llvm-runtime \
         pgxnclient libtap-parser-sourcehandler-pgtap-perl sudo gosu \
-        ca-certificates gnupg2 zip curl git libicu-dev libxml2 locales ssl-cert \
+        ca-certificates gnupg2 zip unzip curl git libicu-dev libxml2 locales ssl-cert \
     && apt-get -y purge postgresql-client-common \
     && apt-get clean \
     && rm -rf /var/cache/apt/* /var/lib/apt/lists/* \

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2023 The PGXN Maintainers.
+Copyright (c) 2020-2024 The PGXN Maintainers.
 
 This module is free software; you can redistribute it and/or modify it under
 the [PostgreSQL License](https://www.opensource.org/licenses/postgresql).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PGXN Extension Build and Test Tools Docker Image
 [![Test & Release Status](https://github.com/pgxn/docker-pgxn-tools/workflows/CI/CD/badge.svg)](https://github.com/pgxn/docker-pgxn-tools/actions)
 
 ``` sh
-docker run -it --rm -w /repo --mount "type=bind,src=$(pwd),dst=/repo" pgxn/pgxn-tools \
+docker run -it --rm -w /repo --volume "$PWD:/repo" pgxn/pgxn-tools \
     sh -c 'pg-start 12 && pg-build-test'
 ```
 
@@ -32,24 +32,24 @@ with `sudo` privileges (already used by `pg-start` and `pg-build-test`):
 
 ``` sh
 docker run -it --rm -w /repo -e AS_USER=worker \
-    --mount "type=bind,src=$(pwd),dst=/repo" pgxn/pgxn-tools \
+    --volume "$PWD:/repo" pgxn/pgxn-tools \
     sh -c 'sudo pg-start 14 && pg-build-test'
 ```
 
 The created user will have the UID 1001 unless `LOCAL_UID` is passed, which can
 usefully be set to the local UID so that the user has permission to access files
-in a mounted directory:
+in a volume:
 
 ``` sh
 docker run -it --rm -w /repo -e AS_USER=worker -e LOCAL_UID=$(id -u) \
-    --mount "type=bind,src=$(pwd),dst=/repo" pgxn/pgxn-tools \
+    --volume "$PWD:/repo" pgxn/pgxn-tools \
     sh -c 'sudo pg-start 14 && pg-build-test'
 ```
 
 If no `LOCAL_UID` is set but `GITHUB_EVENT_PATH` is set (as it is in GitHub
 workflows), the UID will be set to the same value as the owner of the
 `GITHUB_EVENT_PATH` file. This allows the user to have full access to the
-GitHub-mounted project directory.
+GitHub project volume.
 
 ### Postgres User
 
@@ -288,6 +288,31 @@ PostgreSQL database.
 TAP output is suitable for harvesting, analysis, and reporting by [`pg_prove`]
 or other [TAP] tools.
 
+### Installed Packages
+
+The image includes these packages; pass additional packages to
+[`pg-start`](#pg-start) to install them while setting up PostgreSQL.
+
+*   [build-essential](https://packages.debian.org/bookworm/build-essential)
+*   [clang](https://packages.debian.org/bookworm/clang)
+*   [llvm](https://packages.debian.org/bookworm/llvm)
+*   [llvm-dev](https://packages.debian.org/bookworm/llvm-dev)
+*   [llvm-runtime](https://packages.debian.org/bookworm/llvm-runtime)
+*   [pgxnclient](https://packages.debian.org/bookworm/pgxnclient)
+*   [libtap-parser-sourcehandler-pgtap-perl](https://packages.debian.org/bookworm/libtap-parser-sourcehandler-pgtap-perl)
+*   [sudo](https://packages.debian.org/bookworm/sudo)
+*   [gosu](https://packages.debian.org/bookworm/gosu)
+*   [ca-certificates](https://packages.debian.org/bookworm/ca-certificates)
+*   [gnupg2](https://packages.debian.org/bookworm/gnupg2)
+*   [zip](https://packages.debian.org/bookworm/zip)
+*   [unzip](https://packages.debian.org/bookworm/unzip)
+*   [curl](https://packages.debian.org/bookworm/curl)
+*   [git](https://packages.debian.org/bookworm/git)
+*   [libicu-dev](https://packages.debian.org/bookworm/libicu-dev)
+*   [libxml2](https://packages.debian.org/bookworm/libxml2)
+*   [locales](https://packages.debian.org/bookworm/locales)
+*   [ssl-cert](https://packages.debian.org/bookworm/ssl-cert)
+
 Author
 ------
 
@@ -296,7 +321,7 @@ Author
 Copyright and License
 ---------------------
 
-Copyright (c) 2020-2023 The PGXN Maintainers. Distributed under the
+Copyright (c) 2020-2024 The PGXN Maintainers. Distributed under the
 [PostgreSQL License] (see [LICENSE]).
 
   [cli]: https://github.com/pgxn/pgxnclient

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+# Ensure Git can do stuff in the working directory.
+# https://github.com/pgxn/docker-pgxn-tools/issues/5
+git config --system --add safe.directory "$PWD"
+
 # Just continue if unprivileged user not requested.
 [ -z "$AS_USER" ] && exec "$@"
 

--- a/bin/pgxn-bundle
+++ b/bin/pgxn-bundle
@@ -19,10 +19,11 @@ VERSION=${PGXN_DIST_VERSION:-$(perl -MJSON=decode_json -E 'say decode_json(join 
 
 # Now bundle up the distribution for release.
 release=${DISTNAME}-${VERSION}
-echo "Bundling $release.zip..."
-if [ true == "$(git rev-parse --is-inside-work-tree 2>/dev/null)" ]; then
-    git archive --format zip --prefix=${release}/ --output ${release}.zip HEAD
+if [ "true" == "$(git rev-parse --is-inside-work-tree 2>/dev/null)" ]; then
+    echo "Bundling $release.zip from Git repository..."
+    git archive -v --format zip --prefix=${release}/ --output ${release}.zip HEAD
 else
+    echo "Bundling $release.zip with all files..."
     mkdir /tmp/$release
     cp -rf . /tmp/$release
     (cd /tmp && zip -r $release.zip $release)

--- a/test/.gitattributes
+++ b/test/.gitattributes
@@ -1,0 +1,4 @@
+.gitignore export-ignore
+.gitattributes export-ignore
+.github export-ignore
+/runtest.sh export-ignore

--- a/test/runtest.sh
+++ b/test/runtest.sh
@@ -3,7 +3,9 @@
 set -eu
 
 pgversion=$1
+expectgit=${2:-yes}
 export GITHUB_OUTPUT="/tmp/github_output"
+zipfile=widget-1.0.0.zip
 
 cd $(dirname "$0")
 pg-start $pgversion
@@ -11,15 +13,31 @@ pg-build-test
 pgxn-bundle
 make clean
 
-if [ ! -e widget-1.0.0.zip ]; then
-    echo 'ERROR:  No widget-1.0.0.zip file'
+if [ ! -e $zipfile ]; then
+    echo 'ERROR:  No $zipfile file'
     ls -lah
     exit 2
 fi
 
-rm widget-1.0.0.zip
+if [ "$expectgit" = "yes" ]; then
+    # Make sure runtest.sh was omitted thanks to .gitattributes.
+    if unzip -l $zipfile | grep -F runtest.sh; then
+        echo 'ERROR:  Zip file contains runtests.sh and should not'
+        echo '        Did pgxn-bundle use `zip` instead of `git archive`?'
+        exit 2
+    fi
+else
+    # Make sure runtest.sh include in the zip file.
+    if ! unzip -l $zipfile | grep -F runtest.sh; then
+        echo 'ERROR:  Zip file contains runtests.sh and should not'
+        echo '        Did pgxn-bundle use `git archive` instead of `zip`?'
+        exit 2
+    fi
+fi
 
-if ! grep -F "bundle=widget-1.0.0.zip" "$GITHUB_OUTPUT"; then
+rm $zipfile
+
+if ! grep -F "bundle=$zipfile" "$GITHUB_OUTPUT"; then
     echo "ERROR:  Output 'bundle' not appended to $GITHUB_OUTPUT"
     echo File:
     ls -lah "$GITHUB_OUTPUT"


### PR DESCRIPTION
In GitHub actions `pgxn-bundle` was failing to run `git archive` because the `git rev-parse` command it uses to test whether it's working in a Git tree was failing with the suppressed error "detected dubious ownership in repository". Fix it by running this command in `entrypoint.sh`:

```shell
git config --system --add safe.directory "$PWD"
```

So that the working directory is always considered safe. Also tweak the test to fail if it doesn't use `git archive` to zip the files and add a test to ensure it properly falls back on `zip` when not working in a Git project. Fixes #5.

Relatedly, update `pgxn-bundle` to print whether it's archiving from a Git repo or zipping all the files, and turn on verbosity for `git archive` to emit the list of files added to the zip archive.

Other changes:

*   Use the Docker `--volume` option instead of `--mount` in tests and documentation.
*   Upgrade checkout and Docker GitHub actions.
*   Update copyright year.
*   Document installed Apt packages.