### PR TITLE
Add GIT_BUNDLE_OPTS and ZIP_BUNDLE_OPTS variables

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,14 +15,20 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build Image
         run: docker build -t pgxn-tools-test .
-      - name: Test as root
-        run: "docker run -w /repo --rm --volume \"$(pwd):/repo\" pgxn-tools-test ./test/runtest.sh ${{ matrix.pg }}"
-      - name: Test as non-root
-        run: "docker run -w /repo --rm --volume \"$(pwd):/repo\" -e AS_USER=worker pgxn-tools-test ./test/runtest.sh ${{ matrix.pg }}"
-      - name: Test as root without Repo
-        run: "docker run -w /repo --rm --volume \"$(pwd)/test:/repo\" pgxn-tools-test ./runtest.sh ${{ matrix.pg }} nogit"
-      - name: Test as non-root without Repo
-        run: "docker run -w /repo --rm --volume \"$(pwd)/test:/repo\" -e AS_USER=worker pgxn-tools-test ./runtest.sh ${{ matrix.pg }} nogit"
+      # Test with Git repo
+      - name: Test Git as root
+        run: "docker run -w /repo --rm --volume \"$(pwd):/repo\" pgxn-tools-test ./test/runtest.sh ${{ matrix.pg }} git"
+      - name: Test Git as non-root
+        run: "docker run -w /repo --rm --volume \"$(pwd):/repo\" -e AS_USER=worker pgxn-tools-test ./test/runtest.sh ${{ matrix.pg }} git"
+      - name: Test Git with extra file
+        run: "docker run -w /repo --rm --volume \"$(pwd):/repo\" pgxn-tools-test ./test/runtest.sh ${{ matrix.pg }} git yes"
+      # Test without Git repo
+      - name: Test Zip as root
+        run: "docker run -w /repo --rm --volume \"$(pwd)/test:/repo\" pgxn-tools-test ./runtest.sh ${{ matrix.pg }} zip"
+      - name: Test Zip as non-root
+        run: "docker run -w /repo --rm --volume \"$(pwd)/test:/repo\" -e AS_USER=worker pgxn-tools-test ./runtest.sh ${{ matrix.pg }} zip"
+      - name: Test Zip with zip excluded file
+        run: "docker run -w /repo --rm --volume \"$(pwd)/test:/repo\" pgxn-tools-test ./runtest.sh ${{ matrix.pg }} zip yes"
 
   publish:
     # Publish for a tag starting with v.

--- a/bin/pgxn-bundle
+++ b/bin/pgxn-bundle
@@ -20,13 +20,14 @@ VERSION=${PGXN_DIST_VERSION:-$(perl -MJSON=decode_json -E 'say decode_json(join 
 # Now bundle up the distribution for release.
 release=${DISTNAME}-${VERSION}
 if [ "true" == "$(git rev-parse --is-inside-work-tree 2>/dev/null)" ]; then
-    echo "Bundling $release.zip from Git repository..."
-    git archive -v --format zip --prefix=${release}/ --output ${release}.zip HEAD
+    echo "Bundling $release.zip with git archive..."
+    git archive -v --format zip --prefix=${release}/ ${GIT_BUNDLE_OPTS:-} --output ${release}.zip HEAD
 else
-    echo "Bundling $release.zip with all files..."
+    echo "Bundling $release.zip with zip utility..."
     mkdir /tmp/$release
     cp -rf . /tmp/$release
-    (cd /tmp && zip -r $release.zip $release)
+    set -x
+    (cd /tmp && zip -r $release.zip $release ${ZIP_BUNDLE_OPTS:-})
     mv /tmp/$release.zip .
 fi
 echo "bundle=$release.zip" >> $GITHUB_OUTPUT

--- a/test/runtest.sh
+++ b/test/runtest.sh
@@ -3,39 +3,65 @@
 set -eu
 
 pgversion=$1
-expectgit=${2:-yes}
+expectutil=${2:-git}
+testopts=${3:-}
 export GITHUB_OUTPUT="/tmp/github_output"
-zipfile=widget-1.0.0.zip
+prefix=widget-1.0.0
+zipfile="${prefix}.zip"
+extrafile=extra.txt
 
 cd $(dirname "$0")
+
+if [ -n "$testopts" ]; then
+    # Use GIT_BUNDLE_OPTS to add an untracked file to the Git archive or
+    # ZIP_BUNDLE_OPTS to exclude it.
+    echo extra > "$extrafile"
+    export GIT_BUNDLE_OPTS="--add-file $extrafile"
+    export ZIP_BUNDLE_OPTS="--exclude */$extrafile"
+fi
+
 pg-start $pgversion
 pg-build-test
 pgxn-bundle
 make clean
 
-if [ ! -e $zipfile ]; then
-    echo 'ERROR:  No $zipfile file'
+# Make sure pgxn-bundle built the zip file.
+if [ ! -f "$zipfile" ]; then
+    echo ERROR:  Missing $zipfile
     ls -lah
     exit 2
 fi
 
-if [ "$expectgit" = "yes" ]; then
+# Unzip the zipfile.
+unzip "$zipfile"
+
+if [ "$expectutil" = "git" ]; then
     # Make sure runtest.sh was omitted thanks to .gitattributes.
-    if unzip -l $zipfile | grep -F runtest.sh; then
+    if [ -f "$prefix/runtests.sh" ]; then
         echo 'ERROR:  Zip file contains runtests.sh and should not'
         echo '        Did pgxn-bundle use `zip` instead of `git archive`?'
         exit 2
     fi
+    # Make sure the untracked file was added via GIT_BUNDLE_OPTS.
+    if [ -n "$testopts" ] && [ ! -f "$prefix/$extrafile" ]; then
+        echo "ERROR  $prefix/$extrafile not included in archive"
+        exit 2
+    fi
 else
-    # Make sure runtest.sh include in the zip file.
-    if ! unzip -l $zipfile | grep -F runtest.sh; then
+    # Make sure runtest.sh is included in the zip file.
+    if [ ! -f "$prefix/runtest.sh" ]; then
         echo 'ERROR:  Zip file contains runtests.sh and should not'
         echo '        Did pgxn-bundle use `git archive` instead of `zip`?'
         exit 2
     fi
+    # Make sure the extra file was excluded via ZIP_BUNDLE_OPTS.
+    if [ -n "$testopts" ] && [ -f "$prefix/$extrafile" ]; then
+        echo "ERROR  $prefix/$extrafile included in archive but should not be"
+        exit 2
+    fi
 fi
 
-rm $zipfile
+rm -rf "$prefix" "$zipfile"
 
 if ! grep -F "bundle=$zipfile" "$GITHUB_OUTPUT"; then
     echo "ERROR:  Output 'bundle' not appended to $GITHUB_OUTPUT"


### PR DESCRIPTION
The former is passed to `git archive` and the latter to `zip`. Add tests to ensure they can be used for including (with Git) and excluding (with Zip) files. Document these new options in the README.

Also tweak the messages emitted when bundling by Git an Zip.