### PR TITLE
Disable Git safe directory check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN chmod +x /usr/local/bin/apt.postgresql.org.sh \
     && rm -r cpanm ~/.cpanm \
     && echo Defaults	lecture = never >> /etc/sudoers \
     && perl -i -pe 's/\bALL$/NOPASSWD:ALL/g' /etc/sudoers \
-    && echo 'postgres	ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers
+    && echo 'postgres	ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers \
+    # Ensure Git can do stuff in the working directory (issue #5).
+    && git config --system --add safe.directory '*'
 
 COPY bin/* /usr/local/bin/
 

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-# Ensure Git can do stuff in the working directory.
-# https://github.com/pgxn/docker-pgxn-tools/issues/5
-git config --system --add safe.directory "$PWD"
-
 # Just continue if unprivileged user not requested.
 [ -z "$AS_USER" ] && exec "$@"
 


### PR DESCRIPTION
I noticed that `zip` was used instead of `git archive`  GitHub workflows and traced it to this line in `pgxn-bundle`:

```sh
if [ "true" == "$(git rev-parse --is-inside-work-tree 2>/dev/null)" ]; then
```

Removing the STDERR redirect revealed this error:

``` text
fatal: detected dubious ownership in repository at '/repo'
To add an exception for this directory, call:

	git config --global --add safe.directory /repo
```

PR #6 (aac074a) tried to fix it by setting the safe directory in `.entrypoint.sh`, and included tests that replicated the issue. Unfortunately it turns out that using the GitHub workflow [`container` syntax] skips the entrypoint, so it didn't work.

Further research turned up [this SO answer], which reveals that the check can be disabled run setting the `safe.directory` to `'*'`. So add this command to the `Dockerfile`:

```sh
git config --system --add safe.directory '*'
```

This disables the check system-wide in the container by putting the configuration into `/etc/gitconfig`. This persists into the running container, of course, letting any user in the container run Git on files it doesn't own --- in this case, `pgxn-bundle`'s `git archive` command.

Resolves #5.

  [`container` syntax]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontainer
  [this SO answer]: https://stackoverflow.com/a/73100228/79202