### PR TITLE
Add git-archive-all

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ ADD https://salsa.debian.org/postgresql/postgresql-common/-/raw/master/pgdg/apt.
 RUN chmod +x /usr/local/bin/apt.postgresql.org.sh \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        build-essential clang llvm llvm-dev llvm-runtime \
+        build-essential clang llvm llvm-dev llvm-runtime cmake \
         pgxnclient libtap-parser-sourcehandler-pgtap-perl sudo gosu \
-        ca-certificates gnupg2 zip unzip curl git libicu-dev libxml2 locales ssl-cert \
+        ca-certificates gnupg2 zip unzip libarchive-tools curl git libicu-dev libxml2 locales ssl-cert \
     && apt-get -y purge postgresql-client-common \
     && apt-get clean \
     && rm -rf /var/cache/apt/* /var/lib/apt/lists/* \
@@ -18,7 +18,12 @@ RUN chmod +x /usr/local/bin/apt.postgresql.org.sh \
     && perl -i -pe 's/\bALL$/NOPASSWD:ALL/g' /etc/sudoers \
     && echo 'postgres	ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers \
     # Ensure Git can do stuff in the working directory (issue #5).
-    && git config --system --add safe.directory '*'
+    && git config --system --add safe.directory '*' \
+    # Install git-archive-all
+    && curl -O https://raw.githubusercontent.com/Kentzo/git-archive-all/1.23.1/git_archive_all.py \
+    && perl -i -pe 's/python/python3/' git_archive_all.py \
+    && install -m 0755 git_archive_all.py "$(git --exec-path)/git-archive-all" \
+    && rm git_archive_all.py
 
 COPY bin/* /usr/local/bin/
 

--- a/README.md
+++ b/README.md
@@ -252,8 +252,13 @@ test.sh export-ignore
 .github export-ignore
 ```
 
-Use the `$GIT_BUNDLE_OPTS` variable to pass options to the `git archive` command
-or `$ZIP_BUNDLE_OPTS` to pass options to the `zip` command.
+To include Git submodules in the bundle, set [`GIT_ARCHIVE_CMD=archive-all`]
+and `pgxn-bundle` will use [git-archive-all] instead of `git archive` to create
+the bundle.
+
+Use the `$GIT_BUNDLE_OPTS` variable to pass options to the `git archive` (or
+`git archive-all`) command or `$ZIP_BUNDLE_OPTS` to pass options to the `zip`
+command.
 
 For example, if a Git repo contains no `META.json`, but generates it via a
 `make` command, it will not be included in the zip archive, because
@@ -340,6 +345,7 @@ The image includes these packages; pass additional packages to
 *   [llvm](https://packages.debian.org/bookworm/llvm)
 *   [llvm-dev](https://packages.debian.org/bookworm/llvm-dev)
 *   [llvm-runtime](https://packages.debian.org/bookworm/llvm-runtime)
+*   [cmake](https://packages.debian.org/bookworm/cmake)
 *   [pgxnclient](https://packages.debian.org/bookworm/pgxnclient)
 *   [libtap-parser-sourcehandler-pgtap-perl](https://packages.debian.org/bookworm/libtap-parser-sourcehandler-pgtap-perl)
 *   [sudo](https://packages.debian.org/bookworm/sudo)
@@ -348,12 +354,14 @@ The image includes these packages; pass additional packages to
 *   [gnupg2](https://packages.debian.org/bookworm/gnupg2)
 *   [zip](https://packages.debian.org/bookworm/zip)
 *   [unzip](https://packages.debian.org/bookworm/unzip)
+*   [libarchive-tools](https://packages.debian.org/bookworm/libarchive-tools)
 *   [curl](https://packages.debian.org/bookworm/curl)
 *   [git](https://packages.debian.org/bookworm/git)
 *   [libicu-dev](https://packages.debian.org/bookworm/libicu-dev)
 *   [libxml2](https://packages.debian.org/bookworm/libxml2)
 *   [locales](https://packages.debian.org/bookworm/locales)
 *   [ssl-cert](https://packages.debian.org/bookworm/ssl-cert)
+*   [git-archive-all](https://github.com/Kentzo/git-archive-all) (run `git archive-all`)
 
 Author
 ------
@@ -377,7 +385,8 @@ Copyright (c) 2020-2024 The PGXN Maintainers. Distributed under the
   [GithHub Workflow]: https://help.github.com/en/actions/configuring-and-managing-workflows
   [create-release]: https://github.com/actions/create-release
   [upload-release-asset]: https://github.com/actions/upload-release-asset
-  [PGXN]: https;//pgxn.org/ "The PostgreSQL Extension Network"
+  [git-archive-all]: https://github.com/Kentzo/git-archive-all
+  [PGXN]: https://pgxn.org/ "The PostgreSQL Extension Network"
   [David E. Wheeler]: https://justatheory.com/
   [PostgreSQL License]: https://opensource.org/licenses/PostgreSQL
   [LICENSE]: LICENSE

--- a/bin/pgxn-bundle
+++ b/bin/pgxn-bundle
@@ -14,20 +14,26 @@ else
 fi
 
 # Get the extension name and version.
-DISTNAME=${PGXN_DIST_NAME:-$(perl -MJSON=decode_json -E 'say decode_json(join "", <>)->{name}' META.json)}
-VERSION=${PGXN_DIST_VERSION:-$(perl -MJSON=decode_json -E 'say decode_json(join "", <>)->{version}' META.json)}
+DISTNAME="${PGXN_DIST_NAME:-$(perl -MJSON=decode_json -E 'say decode_json(join "", <>)->{name}' META.json)}"
+VERSION="${PGXN_DIST_VERSION:-$(perl -MJSON=decode_json -E 'say decode_json(join "", <>)->{version}' META.json)}"
 
 # Now bundle up the distribution for release.
-release=${DISTNAME}-${VERSION}
+release="${DISTNAME}-${VERSION}"
+cmd="${GIT_ARCHIVE_CMD:-archive}"
 if [ "true" == "$(git rev-parse --is-inside-work-tree 2>/dev/null)" ]; then
     echo "Bundling $release.zip with git archive..."
-    git archive -v --format zip --prefix=${release}/ ${GIT_BUNDLE_OPTS:-} --output ${release}.zip HEAD
+    if [ "${cmd}" = 'archive-all' ]; then
+        git archive-all -v --prefix "${release}/" ${GIT_BUNDLE_OPTS:-} "${release}.zip"
+    else
+        git archive -v --format zip --prefix "${release}/" ${GIT_BUNDLE_OPTS:-} --output "${release}.zip" HEAD
+    fi
 else
     echo "Bundling $release.zip with zip utility..."
-    mkdir /tmp/$release
-    cp -rf . /tmp/$release
+    mkdir "/tmp/$release"
+    cp -rf . "/tmp/$release"
     set -x
-    (cd /tmp && zip -r $release.zip $release ${ZIP_BUNDLE_OPTS:-})
-    mv /tmp/$release.zip .
+    (cd /tmp && zip -r "$release.zip" "$release" ${ZIP_BUNDLE_OPTS:-})
+    mv "/tmp/$release.zip" .
 fi
-echo "bundle=$release.zip" >> $GITHUB_OUTPUT
+
+[ -n "${GITHUB_OUTPUT:-}" ] && echo "bundle=$release.zip" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Add git-archive-all

Install it in Git's exec dir, so `git archive-all` will do the right thing.

Add the `GIT_ARCHIVE_CMD` variable to `pgxn-bundle` To have it use git-archive-all, run

```sh
GIT_ARCHIVE_CMD=archive-all pgxn-bundle
```

Also add `cmake` and `libarchive-tools` to the image and properly quote variables in `pgxn-bundle`.
