### PR TITLE
Document unprivileged user in GitHub workflows

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -5,16 +5,8 @@ set -e
 # Just continue if unprivileged user not requested.
 [ -z "$AS_USER" ] && exec "$@"
 
-USER_ID=${LOCAL_UID:-0}
+USER_ID=${LOCAL_UID:-1001}
 USERNAME=worker
-
-if [ $USER_ID == 0 ]; then
-    if [ -n "${GITHUB_EVENT_PATH}" ]; then
-        USER_ID=$(stat -f %u "${GITHUB_EVENT_PATH}")
-    else
-        USER_ID=1001
-    fi
-fi
 
 echo "Starting with UID $USER_ID"
 useradd --system --create-home --shell /bin/bash -g root -G sudo -u $USER_ID "$AS_USER"


### PR DESCRIPTION
At some point GitHub changed things so that the entrypoint script does not run, so the `AS_USER` variable does nothing. Which is just as well, because that user would have no permissions, so even a checkout will fail.

So remove the GitHib-specific stuff from `entrypoint.sh` and separately document running the container with the CLI and as a GitHub workflow. Add a new section describing how to use `gosu` directly in a GitHub workflow to execute commands as an unprivileged user.

Thanks to @pgguru for figuring out the technique.