### PR TITLE
Add NO_CLUSTER variable

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -32,6 +32,15 @@ jobs:
         run: "docker run -w /repo --rm --volume \"$(pwd)/test:/repo\" -e AS_USER=worker pgxn-tools-test ./runtest.sh ${{ matrix.pg }} zip"
       - name: Test Zip with zip excluded file
         run: "docker run -w /repo --rm --volume \"$(pwd)/test:/repo\" pgxn-tools-test ./runtest.sh ${{ matrix.pg }} zip yes"
+      # Test NO_CLUSTER
+      - name: Test NO_CLUSTER
+        env: { NO_CLUSTER: true }
+        run: |-
+          docker run -w /repo --rm pgxn-tools-test pg-start ${{ matrix.pg }}
+          if [ -d /var/lib/postgresql/16/test ]; then
+            echo "ERROR: /var/lib/postgresql/16/test should not exist!"
+            exit 1;
+          fi
 
   publish:
     # Publish for a tag starting with v.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,31 @@ modified the `postgresql.conf` file), use `pg_ctlcluster` like so:
 pg_ctlcluster 12 test restart
 ```
 
+For finer control over running the PostgreSQL cluster, set the `NO_CLUSTER`
+environment variable to prevent `pg-start` from creating and starting a cluster:
+
+```sh
+env NO_CLUSTER=1 pg-start 14
+```
+
+This will simply install Postgres 14; to start it, use the [`pg_createcluster`]
+command, like so:
+
+```sh
+pg_createcluster --start 14 my14 -p 5414 -- -A trust
+```
+
+This starts a cluster named "my14" on port 5414. This technique is useful to run
+multiple clusters, even different versions at once; just given them unique names and
+ports to run on:
+
+```sh
+env NO_CLUSTER=1 pg-start 15
+pg_createcluster --start 15 my15 -p 5415 -- -A trust
+env NO_CLUSTER=1 pg-start 16
+pg_createcluster --start 16 my16 -p 5416 -- -A trust
+```
+
 ### [`pg-build-test`]
 
 ``` sh
@@ -411,6 +436,7 @@ Copyright (c) 2020-2024 The PGXN Maintainers. Distributed under the
   [upload-release-asset]: https://github.com/actions/upload-release-asset
   [git-archive-all]: https://github.com/Kentzo/git-archive-all
   [PGXN]: https://pgxn.org/ "The PostgreSQL Extension Network"
+  [`pg_createcluster`]: https://manpages.debian.org/buster/postgresql-common/pg_createcluster.1.en.html
   [David E. Wheeler]: https://justatheory.com/
   [PostgreSQL License]: https://opensource.org/licenses/PostgreSQL
   [LICENSE]: LICENSE

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -6,9 +6,8 @@ set -e
 [ -z "$AS_USER" ] && exec "$@"
 
 USER_ID=${LOCAL_UID:-1001}
-USERNAME=worker
 
 echo "Starting with UID $USER_ID"
-useradd --system --create-home --shell /bin/bash -g root -G sudo -u $USER_ID "$AS_USER"
+useradd --system --create-home --shell /bin/bash -g root -G sudo -u "$USER_ID" "$AS_USER"
 export HOME="/home/$AS_USER"
 exec /usr/sbin/gosu "$AS_USER" "$@"

--- a/bin/pg-start
+++ b/bin/pg-start
@@ -14,9 +14,9 @@ PGVERSION=${1:-}
 [[ $PGVERSION =~ ^[0-9]$ ]] && PGVERSION+=.0
 
 set -x
-sudo apt.postgresql.org.sh -i -v $PGVERSION
+sudo apt.postgresql.org.sh -i -v "$PGVERSION"
 if [ $# -gt 1 ]; then
     sudo apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y "${@:2}"
 fi
 
-sudo pg_createcluster --start $PGVERSION test -p "${PGPORT:-5432}" -- -A trust
+[ -z ${NO_CLUSTER+x} ] && sudo pg_createcluster --start "$PGVERSION" test -p "${PGPORT:-5432}" -- -A trust

--- a/bin/pgxn-bundle
+++ b/bin/pgxn-bundle
@@ -23,8 +23,10 @@ cmd="${GIT_ARCHIVE_CMD:-archive}"
 if [ "true" == "$(git rev-parse --is-inside-work-tree 2>/dev/null)" ]; then
     echo "Bundling $release.zip with git ${cmd}..."
     if [ "${cmd}" = 'archive-all' ]; then
+        # shellcheck disable=SC2086 # ${GIT_BUNDLE_OPTS:-} must be unquoted
         git archive-all -v --prefix "${release}/" --force-submodules ${GIT_BUNDLE_OPTS:-} "${release}.zip"
     else
+        # shellcheck disable=SC2086 # ${GIT_BUNDLE_OPTS:-} must be unquoted
         git archive -v --format zip --prefix "${release}/" ${GIT_BUNDLE_OPTS:-} --output "${release}.zip" HEAD
     fi
 else
@@ -32,8 +34,9 @@ else
     mkdir "/tmp/$release"
     cp -rf . "/tmp/$release"
     set -x
+    # shellcheck disable=SC2086 # ${ZIP_BUNDLE_OPTS:-} must be unquoted
     (cd /tmp && zip -r "$release.zip" "$release" ${ZIP_BUNDLE_OPTS:-})
     mv "/tmp/$release.zip" .
 fi
 
-[ -n "${GITHUB_OUTPUT:-}" ] && echo "bundle=$release.zip" >> $GITHUB_OUTPUT
+[ -n "${GITHUB_OUTPUT:-}" ] && echo "bundle=$release.zip" >> "$GITHUB_OUTPUT"

--- a/bin/pgxn-release
+++ b/bin/pgxn-release
@@ -32,10 +32,10 @@ if [ -z ${PGXN_PASSWORD+x} ]; then
 fi
 
 # Release it!
-echo Releasing $zipfile...
+echo "Releasing $zipfile..."
 status=$(curl --user "${PGXN_USERNAME}:${PGXN_PASSWORD}" -F 'submit=Release It!' -F "archive=@${zipfile}" -H 'X-Requested-With: XMLHttpRequest' --silent --output /dev/stderr --write-out "%{http_code}" https://manager.pgxn.org/upload)
 echo
-if test $status -ne 200; then
+if test "$status" -ne 200; then
     echo 'ERROR: Release failed'
     exit 2
 fi

--- a/test/runtest.sh
+++ b/test/runtest.sh
@@ -10,7 +10,7 @@ prefix=widget-1.0.0
 zipfile="${prefix}.zip"
 extrafile=extra.txt
 
-cd $(dirname "$0")
+cd "$(dirname "$0")"
 
 if [ -n "$testopts" ]; then
     # Use GIT_BUNDLE_OPTS to add an untracked file to the Git archive or
@@ -20,7 +20,7 @@ if [ -n "$testopts" ]; then
     export ZIP_BUNDLE_OPTS="--exclude */$extrafile"
 fi
 
-pg-start $pgversion
+pg-start "$pgversion"
 pg-build-test
 pgxn-bundle
 make clean
@@ -39,6 +39,7 @@ if [ "$expectutil" = "git" ]; then
     # Make sure runtest.sh was omitted thanks to .gitattributes.
     if [ -f "$prefix/runtests.sh" ]; then
         echo 'ERROR:  Zip file contains runtests.sh and should not'
+        # shellcheck disable=SC2016
         echo '        Did pgxn-bundle use `zip` instead of `git archive`?'
         exit 2
     fi
@@ -51,6 +52,7 @@ else
     # Make sure runtest.sh is included in the zip file.
     if [ ! -f "$prefix/runtest.sh" ]; then
         echo 'ERROR:  Zip file contains runtests.sh and should not'
+        # shellcheck disable=SC2016
         echo '        Did pgxn-bundle use `git archive` instead of `zip`?'
         exit 2
     fi


### PR DESCRIPTION
Prevents `pg-start` from initializing and starting a cluster. Add docs to describe it and a use case.

Also fix some shell issues reported by shellcheck.