### PR TITLE
Add package argument to pgrx-build-test

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Test with system UID
         run: "docker run -w /repo --rm --volume \"$(pwd):/repo\" -e AS_USER=pgxn_worker -e LOCAL_UID=$(id -u) pgxn-tools-test ./test/pgxs/runtest.sh ${{ matrix.pg }}"
       - name: Test as root
-        run: "docker run -w /repo --rm --volume \"$(pwd):/repo\" pgxn-tools-test ./test/pgxs/runtest.sh ${{ matrix.pg }}"
+        run: "docker run -w /repo --rm --volume \"$(pwd):/repo\" pgxn-tools-test ./test/pgxs/runtest.sh ${{ matrix.pg }} hello"
 
   pgrx:
     name: 🦀 pgrx on Postgres ${{ matrix.pg }}

--- a/README.md
+++ b/README.md
@@ -312,18 +312,20 @@ pg-build-test
 
 ``` sh
 pgrx-build-test
+pgrx-build-test package_name
 ```
 
 Builds, installs, and tests a PostgreSQL [pgrx] extension. It reads the
 required version of [pgrx] from the `Cargo.toml` file, which must be v0.11.4
-or higher. Effectively the equivalent of:
+or higher. Pass the name of the package to build when using a workspace
+configuration. Effectively the equivalent of:
 
 ``` sh
 cargo install --locked cargo-pgrx --version ${PGRX_VERSION}
 cargo pgrx init --pg${PG_VERSION}=$(which pg_config)
-cargo pgrx package --test --pg-config $(which pg_config)
-cargo pgrx test --runas postgres pg${PG_VERSION}
-cargo pgrx install --test --pg-config $(which pg_config)
+cargo pgrx package --test --package ${PACKAGE} --pg-config $(which pg_config)
+cargo pgrx test --runas postgres --package ${PACKAGE} pg${PG_VERSION}
+cargo pgrx install --test --package ${PACKAGE} --pg-config $(which pg_config)
 ```
 
 But a bit more, to ensure that the tests run as the `postgres` user and emits

--- a/bin/pgrx-build-test
+++ b/bin/pgrx-build-test
@@ -12,8 +12,13 @@ my $file = 'Cargo.toml';
 die "No $file file\n" unless -e $file;
 my $cfg = TOML::Parser->new->parse_file($file);
 
-# Look for pgrx.
-my $pgrxv = $cfg->{dependencies}{pgrx} || die "pgrx not found in $file\n";
+# Look for package.
+my $package = shift || $cfg->{package}{name};
+
+# Look for pgrx version.
+my $pgrxv = $cfg->{dependencies}{pgrx}
+    || $cfg->{workspace}{dependencies}{pgrx}
+    || die "pgrx not found in $file\n";
 $pgrxv =~ s/^=//;
 
 # Make sure we support this version of pgrx.
@@ -49,18 +54,20 @@ say "### Initializing pgrx $pgrxv for Postgres $pgv";
 run [qw(cargo pgrx init), "--pg$pgv=$pg_config"] or exit $? >> 8;
 
 # Build the package.
-say "### Building $cfg->{package}{name}";
-run [qw(cargo pgrx package --test --pg-config), $pg_config] or exit $? >> 8;
+say "### Building $package";
+my @common_args = ('--package', $package, '--pg-config', $pg_config);
+run [qw(cargo pgrx package --test), @common_args] or exit $? >> 8;
 
 # Install the extension.
 # (Must come before test: https://github.com/pgcentralfoundation/pgrx/issues/1670)
-say "### Installing $cfg->{package}{name}";
-run [qw(sudo cargo pgrx install --test --pg-config), $pg_config] or exit $? >> 8;
+say "### Installing $package";
+run [qw(sudo cargo pgrx install --test), @common_args] or exit $? >> 8;
 
 # Run the tests as the postgres user.
-say "### Testing $cfg->{package}{name}";
+say "### Testing $package";
 my $res = run [
-    qw(cargo pgrx test --runas postgres --pgdata /var/lib/postgresql/pgrx),
+    qw(cargo pgrx test --runas postgres --pgdata /var/lib/postgresql/pgrx --package),
+    $package,
     "pg$pgv",
 ]; #  or exit $? >> 8;
 
@@ -84,7 +91,7 @@ close $fh;
 exit unless $regress;
 
 # Run installcheck.
-say "### Running installcheck for $cfg->{package}{name}";
+say "### Running installcheck for $package";
 run [qw(make installcheck PGUSER=postgres)] or do {
     my $exit_code = $? >> 8;
     # Try to find regression.diffs.

--- a/test/pgrx/Cargo.toml
+++ b/test/pgrx/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "lib"]
 
+# https://github.com/pgcentralfoundation/pgrx/issues/1966
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(pgrx_embed)"] }
+
 [features]
 default = ["pg17"]
 pg12 = ["pgrx/pg12", "pgrx-tests/pg12" ]

--- a/test/pgrx/runtest.sh
+++ b/test/pgrx/runtest.sh
@@ -3,6 +3,8 @@
 set -eu
 
 pgversion=$1
+package="${2-}"
 cd "$(dirname "$0")"
 pg-start "$pgversion"
-pgrx-build-test
+echo "#################### pgrx-build-test $package ####################"
+if [ -z "$package" ]; then pgrx-build-test; else pgrx-build-test "$package"; fi


### PR DESCRIPTION
For pgrx projects that use workspaces, add support for an optional argument to `pgrx-build-test` that specifies the package to build. Works for both non-workspace projects and regular projects, and remains optional for the latter.